### PR TITLE
Fixed spec.bundle.symbolic-name property generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.glassfish.build</groupId>
     <artifactId>spec-version-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.7-SNAPSHOT</version>
+    <version>1.6-SNAPSHOT</version>
     <name>Spec Version Maven Plugin</name>
     <description>Spec Version Maven Plugin</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.glassfish.build</groupId>
     <artifactId>spec-version-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.6-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <name>Spec Version Maven Plugin</name>
     <description>Spec Version Maven Plugin</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.glassfish.build</groupId>
     <artifactId>spec-version-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.6-SNAPSHOT</version>
+    <version>1.7-SNAPSHOT</version>
     <name>Spec Version Maven Plugin</name>
     <description>Spec Version Maven Plugin</description>
 
@@ -229,8 +229,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/it/modules/jakarta.zucchini-api/pom.xml
+++ b/src/it/modules/jakarta.zucchini-api/pom.xml
@@ -1,0 +1,104 @@
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>${zucchini.groupId}</groupId>
+    <artifactId>${zucchini.artifactId}</artifactId>
+    <version>${zucchini.mavenVersion}</version>
+
+    <name>Zucchini API</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <finalName>${zucchini.finalName}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.glassfish.build</groupId>
+                <artifactId>spec-version-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <specMode>jakarta</specMode>
+                    <spec>
+                        <nonFinal>${zucchini.nonFinal}</nonFinal>
+                        <jarType>${zucchini.jarType}</jarType>
+                        <specVersion>${zucchini.specVersion}</specVersion>
+                        <newSpecVersion>${zucchini.newSpecVersion}</newSpecVersion>
+                        <specImplVersion>${zucchini.specImplVersion}</specImplVersion>
+                        <implVersion>${zucchini.implVersion}</implVersion>
+                        <newImplVersion>${zucchini.newImplVersion}</newImplVersion>
+                        <specBuild>${zucchini.specBuild}</specBuild>
+                        <implBuild>${zucchini.implBuild}</implBuild>
+                        <apiPackage>${zucchini.apiPackage}</apiPackage>
+                        <implNamespace>${zucchini.implNamespace}</implNamespace>
+                    </spec>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>set-spec-properties</goal>
+                            <goal>check-module</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.5</version>
+                <executions>
+                    <execution>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                        <configuration>
+                           <instructions>
+                               <Bundle-Version>${spec.bundle.version}</Bundle-Version>
+                               <Bundle-SymbolicName>${spec.bundle.symbolic-name}</Bundle-SymbolicName>
+                               <Extension-Name>${spec.extension.name}</Extension-Name>
+                               <Implementation-Version>${spec.implementation.version}</Implementation-Version>
+                               <Specification-Version>${spec.specification.version}</Specification-Version>
+                           </instructions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <useDefaultManifestFile>true</useDefaultManifestFile>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.12</version>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/modules/jakarta.zucchini-api/src/main/java/javax/zucchini/Hello.java
+++ b/src/it/modules/jakarta.zucchini-api/src/main/java/javax/zucchini/Hello.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package javax.zucchini;
+
+public interface Hello{
+    public void sayHello();
+}

--- a/src/it/modules/javax.artichaut/pom.xml
+++ b/src/it/modules/javax.artichaut/pom.xml
@@ -37,6 +37,7 @@
                 <artifactId>spec-version-maven-plugin</artifactId>
                 <version>${project.version}</version>
                 <configuration>
+                    <specMode>${artichaut.specMode}</specMode>
                     <spec>
                         <nonFinal>${artichaut.nonFinal}</nonFinal>
                         <jarType>${artichaut.jarType}</jarType>

--- a/src/it/modules/javax.aubergine-api/pom.xml
+++ b/src/it/modules/javax.aubergine-api/pom.xml
@@ -37,6 +37,7 @@
                 <artifactId>spec-version-maven-plugin</artifactId>
                 <version>${project.version}</version>
                 <configuration>
+                    <specMode>${aubergine.specMode}</specMode>
                     <spec>
                         <nonFinal>${aubergine.nonFinal}</nonFinal>
                         <jarType>${aubergine.jarType}</jarType>

--- a/src/it/modules/javax.aubergine/pom.xml
+++ b/src/it/modules/javax.aubergine/pom.xml
@@ -37,6 +37,7 @@
                 <artifactId>spec-version-maven-plugin</artifactId>
                 <version>${project.version}</version>
                 <configuration>
+                    <specMode>${moussaka.specMode}</specMode>
                     <spec>
                         <nonFinal>${moussaka.nonFinal}</nonFinal>
                         <jarType>${moussaka.jarType}</jarType>

--- a/src/it/modules/javax.courgette-api/pom.xml
+++ b/src/it/modules/javax.courgette-api/pom.xml
@@ -37,6 +37,7 @@
                 <artifactId>spec-version-maven-plugin</artifactId>
                 <version>${project.version}</version>
                 <configuration>
+                    <specMode>${courgette.specMode}</specMode>
                     <spec>
                         <nonFinal>${courgette.nonFinal}</nonFinal>
                         <jarType>${courgette.jarType}</jarType>

--- a/src/it/modules/javax.courgette/pom.xml
+++ b/src/it/modules/javax.courgette/pom.xml
@@ -37,6 +37,7 @@
                 <artifactId>spec-version-maven-plugin</artifactId>
                 <version>${project.version}</version>
                 <configuration>
+                    <specMode>${ratatouille.specMode}</specMode>
                     <spec>
                         <nonFinal>${ratatouille.nonFinal}</nonFinal>
                         <jarType>${ratatouille.jarType}</jarType>

--- a/src/main/java/org/glassfish/spec/Spec.java
+++ b/src/main/java/org/glassfish/spec/Spec.java
@@ -35,26 +35,6 @@ import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 public class Spec {
 
     /**
-     * GroupId used for JavaEE specs.
-     */
-    public static final String JAVAX_GROUP_ID = "javax.";
-
-    /**
-     * Package prefix used in JavaEE specs.
-     */
-    public static final String JAVAX_PACKAGE_PREFIX = "javax";
-
-    /**
-     * GroupId used for JakartaEE specs.
-     */
-    public static final String JAKARTA_GROUP_ID = "jakarta.";
-
-    /**
-     * Package prefix used in JakartaEE specs.
-     */
-    public static final String JAKARTA_PACKAGE_PREFIX = "jakarta";
-
-    /**
      * The Spec Artifact.
      */
     private Artifact artifact;
@@ -119,11 +99,6 @@ public class Spec {
      * The Spec Implementation Namespace.
      */
     private String implNamespace;
-
-    /**
-     * The Spec GroupId Prefix.
-     */
-    private String groupIdPrefix;
 
     /**
      * The Spec Final flag.
@@ -203,7 +178,7 @@ public class Spec {
     @SuppressWarnings("checkstyle:MagicNumber")
     private void checkClasses(final JarFile jarfile, final String... pkgs) {
         Enumeration<JarEntry> e = jarfile.entries();
-        Set<String> badPackages = new HashSet<String>();
+        Set<String> badPackages = new HashSet<>();
         entries:
         while (e.hasMoreElements()) {
             JarEntry je = e.nextElement();
@@ -236,7 +211,7 @@ public class Spec {
             // see if we've already complained about it
             if (!badPackages.contains(name)) {
                 badPackages.add(name);
-                if (name.startsWith(groupIdPrefix)) {
+                if (name.startsWith(specMode.grePrefix())) {
                     errors.add(String.format(
                         "ERROR: jar file includes class in wrong package (%s)",
                         name));
@@ -244,6 +219,45 @@ public class Spec {
             }
         }
     }
+
+    /**
+     * Verify that apiPackage starts with proper prefix.
+     * Verification depends on current spec mode:<ul>
+     * <li>javaee: strict check for required prefix</li>
+     * <li>jakarta: both currently supported prefixes are allowed</li></ul>
+     */
+    private void verifyApiPackagePrefix() {
+        switch (specMode) {
+            case JAVAEE:
+                if (!apiPackage.startsWith(specMode.grePrefix())) {
+                    errors.add(String.format(
+                            "WARNING: API packages (%s) must start with \"%s\"",
+                            apiPackage,
+                            specMode.grePrefix()));
+                }
+                break;
+            case JAKARTA:
+                boolean passed = false;
+                for (SpecMode sm : SpecMode.values()) {
+                    if (apiPackage.startsWith(sm.grePrefix())) {
+                        passed = true;
+                    }
+                }
+                if (!passed) {
+                    errors.add(String.format(
+                            "WARNING: API packages (%s) must start with "
+                                    + "\"%s\" or \"%s\"",
+                            apiPackage,
+                            SpecMode.JAVAEE.grePrefix(),
+                            SpecMode.JAKARTA.grePrefix()));
+                }
+                break;
+            // This statement is unreachable, but Java can't live without it.
+            default:
+                throw new IllegalStateException("Unknown specMode value.");
+        }
+    }
+
 
     /**
      * Perform the Spec verification.
@@ -375,11 +389,11 @@ public class Spec {
 
         if (jarType.equals(JarType.api)) {
             // verify that groupId starts with groupIdPrefix
-            if (!artifact.getGroupId().startsWith(groupIdPrefix)) {
+            if (!artifact.getGroupId().startsWith(specMode.grePrefix())) {
                 errors.add(String.format(
                         "WARNING: groupId (%s) must start with \"%s\"",
                         artifact.getGroupId(),
-                        groupIdPrefix));
+                        specMode.grePrefix()));
             }
 
             // verify that artifactId does end with -api
@@ -390,13 +404,7 @@ public class Spec {
                         API_SUFFIX));
             }
 
-            // verify that apiPackage starts with javax
-            if (!apiPackage.startsWith(JAVAX_GROUP_ID)) {
-                errors.add(String.format(
-                        "WARNING: API packages (%s) must start with \"%s\"",
-                        apiPackage,
-                        groupIdPrefix));
-            }
+            verifyApiPackagePrefix();
 
             // verify that Bundle-SymbolicName == apiPackage-api
             String symbolicName = buildBundleSymbolicName();
@@ -463,11 +471,11 @@ public class Spec {
             }
         } else {
             // verify that groupId starts with groupIdPrefix
-            if (artifact.getGroupId().startsWith(groupIdPrefix)) {
+            if (artifact.getGroupId().startsWith(specMode.grePrefix())) {
                 errors.add(String.format(
                         "WARNING: groupId (%s) should not start with \"%s\"",
                         artifact.getGroupId(),
-                        groupIdPrefix));
+                        specMode.grePrefix()));
             }
 
             // verify that artifactId does not end with -api
@@ -478,13 +486,7 @@ public class Spec {
                         API_SUFFIX));
             }
 
-            // verify that apiPackage starts with groupIdPrefix
-            if (!apiPackage.startsWith(groupIdPrefix)) {
-                errors.add(String.format(
-                        "WARNING: API packages (%s) must start with \"%s\"",
-                        apiPackage,
-                        groupIdPrefix));
-            }
+            verifyApiPackagePrefix();
 
             // verify that Bundle-SymbolicName == implNamespace.apiPackage
             String symbolicName = implNamespace + '.' + apiPackage;
@@ -650,16 +652,6 @@ public class Spec {
     }
 
     /**
-     * Set the groupId prefix for this spec.
-     * @param prefix the groupId prefix to use
-     */
-    public void setGroupIdPrefix(final String prefix) {
-        if (prefix != null && !prefix.isEmpty()) {
-            this.groupIdPrefix = prefix;
-        }
-    }
-
-    /**
      * Set the API package for this spec.
      * @param pkg the apiPackage to use
      */
@@ -681,10 +673,10 @@ public class Spec {
                 // more than required.
                 // Doing it manually to make sure this operation is exact.
                 if (apiPackage != null
-                        && apiPackage.startsWith(JAVAX_PACKAGE_PREFIX)) {
-                    return JAKARTA_PACKAGE_PREFIX
+                        && apiPackage.startsWith(SpecMode.JAVAEE.grePrefix())) {
+                    return SpecMode.JAKARTA.grePrefix()
                             + apiPackage.substring(
-                                    JAVAX_PACKAGE_PREFIX.length())
+                                    SpecMode.JAVAEE.grePrefix().length())
                             + Spec.API_SUFFIX;
                 }
                 return apiPackage + Spec.API_SUFFIX;
@@ -808,7 +800,7 @@ public class Spec {
         }
         sb.append("{");
         sb.append(" groupIdPrefix=");
-        sb.append(groupIdPrefix);
+        sb.append(specMode.grePrefix());
         if (specVersion != null && !specVersion.isEmpty()) {
             sb.append(" spec-version=");
             sb.append(specVersion);

--- a/src/main/java/org/glassfish/spec/Spec.java
+++ b/src/main/java/org/glassfish/spec/Spec.java
@@ -51,9 +51,9 @@ public class Spec {
 
     /**
      * The Spec mode (<code>"javaee"</code> or <code>"jakarta"</code>).
-     * Default value is {@link SpecMode.JAVAEE}.
+     * Default value is {@link SpecMode.JAKARTA}.
      */
-    private SpecMode specMode = SpecMode.JAVAEE;
+    private SpecMode specMode = SpecMode.JAKARTA;
 
     /**
      * The Spec Version.

--- a/src/main/java/org/glassfish/spec/SpecMode.java
+++ b/src/main/java/org/glassfish/spec/SpecMode.java
@@ -26,10 +26,10 @@ import java.util.Map;
 public enum SpecMode {
     /** Java EE spec mode for <code>javaee</code> value
      *  of <code>specMode</code> property (default). */
-    JAVAEE("JavaEE"),
+    JAVAEE("JavaEE", "javax."),
     /** Jakarta EE4J spec mode for <code>jakarta</code> value
      *  of <code>specMode</code> property. */
-    JAKARTA("Jakarta");
+    JAKARTA("Jakarta", "jakarta.");
 
     /** Spec mode enumeration elements count. */
     public static final int COUNT = SpecMode.values().length;
@@ -69,11 +69,28 @@ public enum SpecMode {
     private final String name;
 
     /**
+     * Group ID and package prefix for this mode.
+     * Including <code>'.'</code> at the end.
+     */
+    private final String prefix;
+
+    /**
      * Creates an instance of spec plugin mode.
      * @param modeName name of spec plugin mode
+     * @param groupIdPrefix group ID prefix for specific mode
      */
-    SpecMode(final String modeName) {
+    SpecMode(final String modeName, final String groupIdPrefix) {
         this.name = modeName;
+        this.prefix = groupIdPrefix;
+    }
+
+    /**
+     * Returns group ID and package prefix for this mode.
+     * Including  <code>'.'</code> at the end.
+     * @return group ID and package prefix for this mode
+     */
+    public String grePrefix() {
+        return prefix;
     }
 
 }

--- a/src/main/java/org/glassfish/spec/SpecMode.java
+++ b/src/main/java/org/glassfish/spec/SpecMode.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.glassfish.spec;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * API specification modes.
+ * Value of API specification mode is passed as <code>specMode</code>
+ * configuration property.
+ */
+public enum SpecMode {
+    /** Java EE spec mode for <code>javaee</code> value
+     *  of <code>specMode</code> property (default). */
+    JAVAEE("JavaEE"),
+    /** Jakarta EE4J spec mode for <code>jakarta</code> value
+     *  of <code>specMode</code> property. */
+    JAKARTA("Jakarta");
+
+    /** Spec mode enumeration elements count. */
+    public static final int COUNT = SpecMode.values().length;
+
+    /** Spec mode name to SpecMode instance conversion map. */
+    private static final Map<String, SpecMode> STR_TO_SPECMODE_MAP
+            = new HashMap<>(COUNT);
+
+    // Initialize spec mode name to SpecMode instance conversion
+    // map.
+    static {
+        for (SpecMode sm : SpecMode.values()) {
+            STR_TO_SPECMODE_MAP.put(sm.name.toLowerCase(), sm);
+        }
+    }
+
+    /**
+     * Get spec plugin mode with corresponding name.
+     * @param name name of spec plugin mode
+     * @return spec plugin mode with corresponding name or default
+     *         <code>JAVAEE</code> value when no appropriate value
+     *         was found.
+     */
+    public static SpecMode getSpecMode(final String name) {
+        if (name == null) {
+            return JAVAEE;
+        }
+        final SpecMode sm = STR_TO_SPECMODE_MAP.get(name.toLowerCase());
+        return sm != null ? sm : JAVAEE;
+    }
+
+    /**
+     * Name of spec plugin mode.
+     * Value of <code>name.toLowerCase()</code> must match corresponding
+     * <code>specMode</code> lowercase value from <code>pom.xml</code>.
+     */
+    private final String name;
+
+    /**
+     * Creates an instance of spec plugin mode.
+     * @param modeName name of spec plugin mode
+     */
+    SpecMode(final String modeName) {
+        this.name = modeName;
+    }
+
+}

--- a/src/main/java/org/glassfish/spec/maven/CheckModuleMojo.java
+++ b/src/main/java/org/glassfish/spec/maven/CheckModuleMojo.java
@@ -61,7 +61,7 @@ public final class CheckModuleMojo extends AbstractMojo {
     /**
      * Mode. Allowed values are "javaee", "jakarta"
      */
-    @Parameter(property = "specMode", defaultValue = "javaee")
+    @Parameter(property = "specMode", defaultValue = "jakarta")
     private String specMode;
 
     /**

--- a/src/main/java/org/glassfish/spec/maven/CheckModuleMojo.java
+++ b/src/main/java/org/glassfish/spec/maven/CheckModuleMojo.java
@@ -86,7 +86,6 @@ public final class CheckModuleMojo extends AbstractMojo {
             }
 
             spec.setSpecMode(specMode);
-            spec.setGroupIdPrefix(specMode.equals("jakarta") ? Spec.JAKARTA_GROUP_ID : Spec.JAVAX_GROUP_ID);
             spec.setArtifact(new Artifact(
                     project.getGroupId(),
                     project.getArtifactId(),

--- a/src/main/java/org/glassfish/spec/maven/CheckModuleMojo.java
+++ b/src/main/java/org/glassfish/spec/maven/CheckModuleMojo.java
@@ -85,6 +85,7 @@ public final class CheckModuleMojo extends AbstractMojo {
                 spec = new Spec();
             }
 
+            spec.setSpecMode(specMode);
             spec.setGroupIdPrefix(specMode.equals("jakarta") ? Spec.JAKARTA_GROUP_ID : Spec.JAVAX_GROUP_ID);
             spec.setArtifact(new Artifact(
                     project.getGroupId(),

--- a/src/main/java/org/glassfish/spec/maven/CommandLineMojo.java
+++ b/src/main/java/org/glassfish/spec/maven/CommandLineMojo.java
@@ -328,7 +328,6 @@ public final class CommandLineMojo extends AbstractMojo {
         Spec spec = new Spec();
         spec.setSpecMode(specMode);
         spec.setArtifact(artifact);
-        spec.setGroupIdPrefix(specMode.equals("jakarta") ? Spec.JAKARTA_GROUP_ID : Spec.JAVAX_GROUP_ID);
         spec.setSpecVersion(specVersion);
         spec.setNewSpecVersion(newSpecVersion);
         spec.setSpecImplVersion(specImplVersion);

--- a/src/main/java/org/glassfish/spec/maven/CommandLineMojo.java
+++ b/src/main/java/org/glassfish/spec/maven/CommandLineMojo.java
@@ -76,7 +76,7 @@ public final class CommandLineMojo extends AbstractMojo {
     /**
      * Mode. Allowed values are "javaee", "jakarta"
      */
-    @Parameter(property = "specMode", defaultValue = "javaee")
+    @Parameter(property = "specMode", defaultValue = "jakarta")
     private String specMode;
 
     /**

--- a/src/main/java/org/glassfish/spec/maven/CommandLineMojo.java
+++ b/src/main/java/org/glassfish/spec/maven/CommandLineMojo.java
@@ -326,6 +326,7 @@ public final class CommandLineMojo extends AbstractMojo {
 
         // TODO remove mojo parameters and replace with spec.
         Spec spec = new Spec();
+        spec.setSpecMode(specMode);
         spec.setArtifact(artifact);
         spec.setGroupIdPrefix(specMode.equals("jakarta") ? Spec.JAKARTA_GROUP_ID : Spec.JAVAX_GROUP_ID);
         spec.setSpecVersion(specVersion);

--- a/src/main/java/org/glassfish/spec/maven/SetPropertiesMojo.java
+++ b/src/main/java/org/glassfish/spec/maven/SetPropertiesMojo.java
@@ -47,7 +47,7 @@ public final class SetPropertiesMojo extends AbstractMojo {
     /**
      * Mode. Allowed values are "javaee", "jakarta"
      */
-    @Parameter(property = "specMode", defaultValue = "javaee")
+    @Parameter(property = "specMode", defaultValue = "jakarta")
     private String specMode;
 
     /**

--- a/src/main/java/org/glassfish/spec/maven/SetPropertiesMojo.java
+++ b/src/main/java/org/glassfish/spec/maven/SetPropertiesMojo.java
@@ -45,6 +45,12 @@ public final class SetPropertiesMojo extends AbstractMojo {
     private MavenProject project;
 
     /**
+     * Mode. Allowed values are "javaee", "jakarta"
+     */
+    @Parameter(property = "specMode", defaultValue = "javaee")
+    private String specMode;
+
+    /**
      * The spec.
      */
     @Parameter(property = "spec", required = true)
@@ -52,11 +58,11 @@ public final class SetPropertiesMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        spec.setSpecMode(specMode);
         spec.setArtifact(new Artifact(
                 project.getGroupId(),
                 project.getArtifactId(),
                 project.getVersion()));
-
         Properties specProps = spec.getMetadata().getProperties();
 
         getLog().info("");

--- a/src/test/java/org/glassfish/spec/test/TestSpec.java
+++ b/src/test/java/org/glassfish/spec/test/TestSpec.java
@@ -45,7 +45,6 @@ public abstract class TestSpec extends Spec {
             String jarType,
             boolean nonFinal) {
         super();
-        setGroupIdPrefix("javax.");
         setArtifact(artifact);
         setSpecVersion(specVersion);
         setNewSpecVersion(newSpecVersion);

--- a/src/test/java/org/glassfish/spec/test/TestSpec.java
+++ b/src/test/java/org/glassfish/spec/test/TestSpec.java
@@ -43,8 +43,10 @@ public abstract class TestSpec extends Spec {
             String apiPackage,
             String implNamespace,
             String jarType,
+            String specMode,
             boolean nonFinal) {
         super();
+        setSpecMode(specMode);
         setArtifact(artifact);
         setSpecVersion(specVersion);
         setNewSpecVersion(newSpecVersion);

--- a/src/test/java/org/glassfish/spec/test/integration/MetadataTest.java
+++ b/src/test/java/org/glassfish/spec/test/integration/MetadataTest.java
@@ -20,6 +20,7 @@ import org.glassfish.spec.test.sets.Courgette;
 import org.glassfish.spec.test.sets.Ratatouille;
 import org.glassfish.spec.test.sets.Aubergine;
 import org.glassfish.spec.test.sets.Moussaka;
+import org.glassfish.spec.test.sets.Zucchini;
 import org.junit.Test;
 
 /**
@@ -36,6 +37,11 @@ public class MetadataTest {
     @Test
     public void verifyCourgetteMetadata() {
         new Courgette().assertMetadataFromJar();
+    }
+
+    @Test
+    public void verifyZucchiniMetadata() {
+        new Zucchini().assertMetadataFromJar();
     }
 
     @Test

--- a/src/test/resources/org/glassfish/spec/test/sets/Artichaut.java
+++ b/src/test/resources/org/glassfish/spec/test/sets/Artichaut.java
@@ -40,6 +40,7 @@ public class Artichaut extends TestSpec {
                 "${artichaut.apiPackage}",
                 "${artichaut.implNamespace}",
                 "${artichaut.jarType}",
+                "${artichaut.specMode}",
                 Boolean.parseBoolean("${artichaut.nonFinal}"));
     }
 

--- a/src/test/resources/org/glassfish/spec/test/sets/Aubergine.java
+++ b/src/test/resources/org/glassfish/spec/test/sets/Aubergine.java
@@ -40,6 +40,7 @@ public class Aubergine extends TestSpec {
                 "${aubergine.apiPackage}",
                 "${aubergine.implNamespace}",
                 "${aubergine.jarType}",
+                "${aubergine.specMode}",
                 Boolean.parseBoolean("${aubergine.nonFinal}"));
     }
 

--- a/src/test/resources/org/glassfish/spec/test/sets/Courgette.java
+++ b/src/test/resources/org/glassfish/spec/test/sets/Courgette.java
@@ -40,6 +40,7 @@ public class Courgette extends TestSpec {
                 "${courgette.apiPackage}",
                 "${courgette.implNamespace}",
                 "${courgette.jarType}",
+                "${courgette.specMode}",
                 Boolean.parseBoolean("${courgette.nonFinal}"));
     }
 

--- a/src/test/resources/org/glassfish/spec/test/sets/Moussaka.java
+++ b/src/test/resources/org/glassfish/spec/test/sets/Moussaka.java
@@ -40,6 +40,7 @@ public class Moussaka extends TestSpec {
                 "${moussaka.apiPackage}",
                 "${moussaka.implNamespace}",
                 "${moussaka.jarType}",
+                "${moussaka.specMode}",
                 Boolean.parseBoolean("${moussaka.nonFinal}"));
     }
 

--- a/src/test/resources/org/glassfish/spec/test/sets/Ratatouille.java
+++ b/src/test/resources/org/glassfish/spec/test/sets/Ratatouille.java
@@ -39,6 +39,7 @@ public class Ratatouille extends TestSpec {
                 "${ratatouille.apiPackage}",
                 "${ratatouille.implNamespace}",
                 "${ratatouille.jarType}",
+                "${ratatouille.specMode}",
                 Boolean.parseBoolean("${ratatouille.nonFinal}"));
     }
 

--- a/src/test/resources/org/glassfish/spec/test/sets/Zucchini.java
+++ b/src/test/resources/org/glassfish/spec/test/sets/Zucchini.java
@@ -40,6 +40,7 @@ public class Zucchini extends TestSpec {
                 "${zucchini.apiPackage}",
                 "${zucchini.implNamespace}",
                 "${zucchini.jarType}",
+                "${zucchini.specMode}",
                 Boolean.parseBoolean("${zucchini.nonFinal}"));
     }
 

--- a/src/test/resources/org/glassfish/spec/test/sets/Zucchini.java
+++ b/src/test/resources/org/glassfish/spec/test/sets/Zucchini.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.spec.test.sets;
+
+import org.glassfish.spec.Artifact;
+import org.glassfish.spec.test.TestSpec;
+
+/**
+ *
+ * @author Romain Grecourt
+ */
+public class Zucchini extends TestSpec {
+
+    public Zucchini() {
+        super(new Artifact(
+                "${zucchini.groupId}",
+                "${zucchini.artifactId}",
+                "${zucchini.mavenVersion}"),
+                "${zucchini.specVersion}",
+                "${zucchini.newSpecVersion}",
+                "${zucchini.specImplVersion}",
+                "${zucchini.implVersion}",
+                "${zucchini.newImplVersion}",
+                "${zucchini.specBuild}",
+                "${zucchini.implBuild}",
+                "${zucchini.apiPackage}",
+                "${zucchini.implNamespace}",
+                "${zucchini.jarType}",
+                Boolean.parseBoolean("${zucchini.nonFinal}"));
+    }
+
+    @Override
+    public String getExpectedBundleVersion() {
+        return "${zucchini.bundleVersion}";
+    }
+
+    @Override
+    public String getExpectedBundleSpecVersion() {
+        return "${zucchini.bundleSpecVersion}";
+    }
+
+    @Override
+    public String getExpectedBundleSymbolicName() {
+        return "${zucchini.bundleSymbolicName}";
+    }
+
+    @Override
+    public String getExpectedJarExtensionName() {
+        return "${zucchini.jarExtensionName}";
+    }
+
+    @Override
+    public String getExpectedJarImplementationVersion() {
+        return "${zucchini.jarImplementationVersion}";
+    }
+
+    @Override
+    public String getExpectedJarSpecificationVersion() {
+        return "${zucchini.jarSpecificationVersion}";
+    }
+
+    @Override
+    public String getJarPath() {
+       return "target/it/modules/${zucchini.artifactId}/target/${zucchini.artifactId}.jar";
+    }
+}

--- a/src/test/resources/test-sets.properties
+++ b/src/test/resources/test-sets.properties
@@ -61,6 +61,30 @@ courgette.bundleSpecVersion=${courgette.specVersion}
 courgette.mavenVersion=${courgette.specImplVersion}
 courgette.finalName=${courgette.artifactId}
 
+# zucchini is a final API in Jakarta mode with old javax api package
+zucchini.apiPackage=javax.zucchini
+zucchini.implNamespace=
+zucchini.specVersion=2.4
+zucchini.newSpecVersion=
+zucchini.specImplVersion=2.4.3
+zucchini.specMode=jakarta
+zucchini.implVersion=
+zucchini.newImplVersion=
+zucchini.specBuild=
+zucchini.implBuild=
+zucchini.nonFinal=false
+zucchini.jarType=api
+zucchini.groupId=jakarta.zucchini
+zucchini.artifactId=${zucchini.groupId}-api
+zucchini.jarImplementationVersion=${zucchini.specImplVersion}
+zucchini.jarExtensionName=${zucchini.apiPackage}
+zucchini.jarSpecificationVersion=${zucchini.specVersion}
+zucchini.bundleVersion=${zucchini.specImplVersion}
+zucchini.bundleSymbolicName=jakarta.zucchini-api
+zucchini.bundleSpecVersion=${zucchini.specVersion}
+zucchini.mavenVersion=${zucchini.specImplVersion}
+zucchini.finalName=${zucchini.artifactId}
+
 # ratatouille is a final standalone of javax.courgette
 ratatouille.apiPackage=${courgette.apiPackage}
 ratatouille.implNamespace=org.ratatouille

--- a/src/test/resources/test-sets.properties
+++ b/src/test/resources/test-sets.properties
@@ -15,6 +15,7 @@
 #
 
 # Womba is a non final API
+aubergine.specMode=javaee
 aubergine.apiPackage=javax.aubergine
 aubergine.implNamespace=
 aubergine.specVersion=2.0
@@ -39,6 +40,7 @@ aubergine.bundleSpecVersion=${aubergine.bundleVersion}
 aubergine.finalName=${aubergine.artifactId}
 
 # courgette is a final API
+courgette.specMode=javaee
 courgette.apiPackage=javax.courgette
 courgette.implNamespace=
 courgette.specVersion=2.4
@@ -62,12 +64,12 @@ courgette.mavenVersion=${courgette.specImplVersion}
 courgette.finalName=${courgette.artifactId}
 
 # zucchini is a final API in Jakarta mode with old javax api package
+zucchini.specMode=jakarta
 zucchini.apiPackage=javax.zucchini
 zucchini.implNamespace=
 zucchini.specVersion=2.4
 zucchini.newSpecVersion=
 zucchini.specImplVersion=2.4.3
-zucchini.specMode=jakarta
 zucchini.implVersion=
 zucchini.newImplVersion=
 zucchini.specBuild=
@@ -86,6 +88,7 @@ zucchini.mavenVersion=${zucchini.specImplVersion}
 zucchini.finalName=${zucchini.artifactId}
 
 # ratatouille is a final standalone of javax.courgette
+ratatouille.specMode=javaee
 ratatouille.apiPackage=${courgette.apiPackage}
 ratatouille.implNamespace=org.ratatouille
 ratatouille.specVersion=1.5
@@ -109,6 +112,7 @@ ratatouille.bundleSpecVersion=${ratatouille.specVersion}
 ratatouille.finalName=${ratatouille.artifactId}
 
 # moussaka is a non final standalone of javax.aubergine
+moussaka.specMode=javaee
 moussaka.apiPackage=${aubergine.apiPackage}
 moussaka.implNamespace=org.moussaka
 moussaka.specVersion=1.4
@@ -133,6 +137,7 @@ moussaka.bundleSpecVersion=${moussaka.specVersion}.99.b${moussaka.buildNumber}
 moussaka.finalName=${moussaka.artifactId}
 
 # artichaut is a final api with version 1.0
+artichaut.specMode=javaee
 artichaut.apiPackage=javax.artichaut
 artichaut.implNamespace=
 artichaut.specVersion=1.0


### PR DESCRIPTION
spec.bundle.symbolic-name property should start with "jakarta" when
`jarType == "API" && specMode == "jakarta"`

Changed Spec class to contain specMode value which is implemented as enum.
Generated spec.bundle.symbolic-name property value depends on specMode in jarType == "API" branch:
- javaee: property generation remains unchanged
- jakarta: "javax" apiPackage string prefix is replaced with "jakarta"

Added jakarta.zucchini-api project into tests to verify this change and to have at least one jakarta project in integration tests.
