### PR TITLE
Set explicit JDK versions in IT tests for JDK 11+ usage

### DIFF
--- a/src/it/modules/jakarta.zucchini-api/pom.xml
+++ b/src/it/modules/jakarta.zucchini-api/pom.xml
@@ -27,6 +27,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <build>

--- a/src/it/modules/javax.artichaut/pom.xml
+++ b/src/it/modules/javax.artichaut/pom.xml
@@ -27,6 +27,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
     
     <build>

--- a/src/it/modules/javax.aubergine-api/pom.xml
+++ b/src/it/modules/javax.aubergine-api/pom.xml
@@ -27,6 +27,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
     
     <build>

--- a/src/it/modules/javax.aubergine/pom.xml
+++ b/src/it/modules/javax.aubergine/pom.xml
@@ -27,6 +27,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
     
     <build>

--- a/src/it/modules/javax.courgette-api/pom.xml
+++ b/src/it/modules/javax.courgette-api/pom.xml
@@ -27,6 +27,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
     
     <build>

--- a/src/it/modules/javax.courgette/pom.xml
+++ b/src/it/modules/javax.courgette/pom.xml
@@ -27,6 +27,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
     
     <build>


### PR DESCRIPTION
Set UTF-8 for reporting and JDK 1.8 for source and target to prevent warnings and errors when using JDK 11+ to compile.

Signed-off-by: arjantijms <arjan.tijms@gmail.com>