### PR TITLE
Use primitive boolean to keep help property

### DIFF
--- a/src/main/java/org/glassfish/spec/maven/CommandLineMojo.java
+++ b/src/main/java/org/glassfish/spec/maven/CommandLineMojo.java
@@ -198,9 +198,9 @@ public final class CommandLineMojo extends AbstractMojo {
             printParam("specimplversion", "vers\tversion number of the API classes");
             printParam("implversion", "version\tversion number of the implementation");
             printParam("newspecversion", "vers\tversion number of the spec under development");
-            printParam("specbuild", "num\tbuild number of spec API jar file");
+            printParam("specbuild", "num\t\tbuild number of spec API jar file");
             printParam("newimplversion", "vers\tversion number of the implementation when final");
-            printParam("implbuild", "num\tbuild number of implementation jar file");
+            printParam("implbuild", "num\t\tbuild number of implementation jar file");
             printParam("specMode", "specMode\t'javaee' or 'jakarta'");
             return;
         }

--- a/src/main/java/org/glassfish/spec/maven/CommandLineMojo.java
+++ b/src/main/java/org/glassfish/spec/maven/CommandLineMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -136,8 +136,8 @@ public final class CommandLineMojo extends AbstractMojo {
     /**
      * Show the usage.
      */
-    @Parameter(property = "help")
-    private Boolean help;
+    @Parameter(property = "help", defaultValue = "true")
+    private boolean help;
 
     /**
      * The system console.
@@ -186,6 +186,7 @@ public final class CommandLineMojo extends AbstractMojo {
     })
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (help) {
+            printParam("help", "\t\t\tprint usage (this message)");
             printParam("properties", "file\tread settings from property file");
             printParam("nonfinal", "\t\tnon-final specification");
             printParam("standalone", "\t\tAPI has a standalone implementation");


### PR DESCRIPTION
With #8 not implemented/accepted I propose this change to avoid NPEx on unboxing at:
https://github.com/eclipse-ee4j/glassfish-spec-version-maven-plugin/blob/9c0026f2700d10cc0fbed98a67a773a78ad8026e/src/main/java/org/glassfish/spec/maven/CommandLineMojo.java#L188

```
[ERROR] Failed to execute goal org.glassfish.build:spec-version-maven-plugin:2.0:cli (default-cli) on project spec-version-maven-plugin: Execution default-cli of goal org.glassfish.build:spec-version-maven-plugin:2.0:cli failed.: NullPointerException -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.glassfish.build:spec-version-maven-plugin:2.0:cli (default-cli) on project spec-version-maven-plugin: Execution default-cli of goal org.glassfish.build:spec-version-maven-plugin:2.0:cli failed.
[...]
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution default-cli of goal org.glassfish.build:spec-version-maven-plugin:2.0:cli failed.
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:148)
[...]
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: java.lang.NullPointerException
    at org.glassfish.spec.maven.CommandLineMojo.execute (CommandLineMojo.java:188)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)

```
when `cli` goal is called without `help` argument.

As `help` is currently kind of mandatory - its default is set to `true`, to display help message if it's missing.

---
As I'm editing this file I also propose cosmetic fix in displayed args description.