### PR TITLE
Do not suppress CheckStyle LineLength

### DIFF
--- a/src/main/java/org/glassfish/spec/maven/CheckModuleMojo.java
+++ b/src/main/java/org/glassfish/spec/maven/CheckModuleMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -71,7 +71,6 @@ public final class CheckModuleMojo extends AbstractMojo {
     private Spec spec;
 
     @Override
-    @SuppressWarnings("checkstyle:LineLength")
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (module == null || !module.exists()) {
             module = project.getArtifact().getFile();


### PR DESCRIPTION
With https://github.com/eclipse-ee4j/glassfish-spec-version-maven-plugin/blob/a21ce870a4ffea3895de162c01ff7b4c754446da/checkstyle.xml#L41-L43
in place, this suppression can be removed.