### PR TITLE
Introduce parent pom for ITs

### DIFF
--- a/src/it/modules/jakarta.zucchini-api/pom.xml
+++ b/src/it/modules/jakarta.zucchini-api/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.build.</groupId>
         <artifactId>spec-version-maven-plugin-it-parent</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>@project.version@</version>
     </parent>
 
     <groupId>${zucchini.groupId}</groupId>

--- a/src/it/modules/jakarta.zucchini-api/pom.xml
+++ b/src/it/modules/jakarta.zucchini-api/pom.xml
@@ -86,14 +86,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
-                <configuration>
-                    <useDefaultManifestFile>true</useDefaultManifestFile>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/modules/jakarta.zucchini-api/pom.xml
+++ b/src/it/modules/jakarta.zucchini-api/pom.xml
@@ -67,24 +67,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.5</version>
-                <executions>
-                    <execution>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                        <configuration>
-                           <instructions>
-                               <Bundle-Version>${spec.bundle.version}</Bundle-Version>
-                               <Bundle-SymbolicName>${spec.bundle.symbolic-name}</Bundle-SymbolicName>
-                               <Extension-Name>${spec.extension.name}</Extension-Name>
-                               <Implementation-Version>${spec.implementation.version}</Implementation-Version>
-                               <Specification-Version>${spec.specification.version}</Specification-Version>
-                           </instructions>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/it/modules/jakarta.zucchini-api/pom.xml
+++ b/src/it/modules/jakarta.zucchini-api/pom.xml
@@ -94,14 +94,6 @@
                     <useDefaultManifestFile>true</useDefaultManifestFile>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/modules/jakarta.zucchini-api/pom.xml
+++ b/src/it/modules/jakarta.zucchini-api/pom.xml
@@ -32,14 +32,6 @@
 
     <name>Zucchini API</name>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
-
     <build>
         <finalName>${zucchini.finalName}</finalName>
         <plugins>

--- a/src/it/modules/jakarta.zucchini-api/pom.xml
+++ b/src/it/modules/jakarta.zucchini-api/pom.xml
@@ -64,10 +64,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/modules/jakarta.zucchini-api/pom.xml
+++ b/src/it/modules/jakarta.zucchini-api/pom.xml
@@ -55,14 +55,6 @@
                         <implNamespace>${zucchini.implNamespace}</implNamespace>
                     </spec>
                 </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>set-spec-properties</goal>
-                            <goal>check-module</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/it/modules/jakarta.zucchini-api/pom.xml
+++ b/src/it/modules/jakarta.zucchini-api/pom.xml
@@ -19,6 +19,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.build.</groupId>
+        <artifactId>spec-version-maven-plugin-it-parent</artifactId>
+        <version>2.1-SNAPSHOT</version>
+    </parent>
+
     <groupId>${zucchini.groupId}</groupId>
     <artifactId>${zucchini.artifactId}</artifactId>
     <version>${zucchini.mavenVersion}</version>

--- a/src/it/modules/javax.artichaut/pom.xml
+++ b/src/it/modules/javax.artichaut/pom.xml
@@ -86,14 +86,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
-                <configuration>
-                    <useDefaultManifestFile>true</useDefaultManifestFile>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/modules/javax.artichaut/pom.xml
+++ b/src/it/modules/javax.artichaut/pom.xml
@@ -67,24 +67,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.5</version>
-                <executions>
-                    <execution>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                        <configuration>
-                           <instructions>
-                               <Bundle-Version>${spec.bundle.version}</Bundle-Version>
-                               <Bundle-SymbolicName>${spec.bundle.symbolic-name}</Bundle-SymbolicName>
-                               <Extension-Name>${spec.extension.name}</Extension-Name>
-                               <Implementation-Version>${spec.implementation.version}</Implementation-Version>
-                               <Specification-Version>${spec.specification.version}</Specification-Version>
-                           </instructions>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/it/modules/javax.artichaut/pom.xml
+++ b/src/it/modules/javax.artichaut/pom.xml
@@ -94,14 +94,6 @@
                     <useDefaultManifestFile>true</useDefaultManifestFile>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/modules/javax.artichaut/pom.xml
+++ b/src/it/modules/javax.artichaut/pom.xml
@@ -19,6 +19,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.build.</groupId>
+        <artifactId>spec-version-maven-plugin-it-parent</artifactId>
+        <version>2.1-SNAPSHOT</version>
+    </parent>
+
     <groupId>${artichaut.groupId}</groupId>
     <artifactId>${artichaut.artifactId}</artifactId>
     <version>${artichaut.mavenVersion}</version>

--- a/src/it/modules/javax.artichaut/pom.xml
+++ b/src/it/modules/javax.artichaut/pom.xml
@@ -64,10 +64,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/modules/javax.artichaut/pom.xml
+++ b/src/it/modules/javax.artichaut/pom.xml
@@ -55,14 +55,6 @@
                         <implNamespace>${artichaut.implNamespace}</implNamespace>
                     </spec>
                 </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>set-spec-properties</goal>
-                            <goal>check-module</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/it/modules/javax.artichaut/pom.xml
+++ b/src/it/modules/javax.artichaut/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.build.</groupId>
         <artifactId>spec-version-maven-plugin-it-parent</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>@project.version@</version>
     </parent>
 
     <groupId>${artichaut.groupId}</groupId>

--- a/src/it/modules/javax.artichaut/pom.xml
+++ b/src/it/modules/javax.artichaut/pom.xml
@@ -32,14 +32,6 @@
 
     <name>Artichaut API</name>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
-    
     <build>
         <finalName>${artichaut.finalName}</finalName>
         <plugins>

--- a/src/it/modules/javax.aubergine-api/pom.xml
+++ b/src/it/modules/javax.aubergine-api/pom.xml
@@ -32,14 +32,6 @@
 
     <name>Aubergine API</name>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
-    
     <build>
         <finalName>${aubergine.finalName}</finalName>
         <plugins>

--- a/src/it/modules/javax.aubergine-api/pom.xml
+++ b/src/it/modules/javax.aubergine-api/pom.xml
@@ -38,7 +38,6 @@
             <plugin>
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>spec-version-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <configuration>
                     <specMode>${aubergine.specMode}</specMode>
                     <spec>
@@ -55,14 +54,6 @@
                         <implNamespace>${aubergine.implNamespace}</implNamespace>
                     </spec>
                 </configuration>             
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>set-spec-properties</goal>
-                            <goal>check-module</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/it/modules/javax.aubergine-api/pom.xml
+++ b/src/it/modules/javax.aubergine-api/pom.xml
@@ -86,14 +86,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
-                <configuration>
-                    <useDefaultManifestFile>true</useDefaultManifestFile>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/modules/javax.aubergine-api/pom.xml
+++ b/src/it/modules/javax.aubergine-api/pom.xml
@@ -67,24 +67,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.5</version>
-                <executions>
-                    <execution>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                        <configuration>
-                           <instructions>
-                               <Bundle-Version>${spec.bundle.version}</Bundle-Version>
-                               <Bundle-SymbolicName>${spec.bundle.symbolic-name}</Bundle-SymbolicName>
-                               <Extension-Name>${spec.extension.name}</Extension-Name>
-                               <Implementation-Version>${spec.implementation.version}</Implementation-Version>
-                               <Specification-Version>${spec.specification.version}</Specification-Version>
-                           </instructions>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/it/modules/javax.aubergine-api/pom.xml
+++ b/src/it/modules/javax.aubergine-api/pom.xml
@@ -94,14 +94,6 @@
                     <useDefaultManifestFile>true</useDefaultManifestFile>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/modules/javax.aubergine-api/pom.xml
+++ b/src/it/modules/javax.aubergine-api/pom.xml
@@ -64,10 +64,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/modules/javax.aubergine-api/pom.xml
+++ b/src/it/modules/javax.aubergine-api/pom.xml
@@ -19,6 +19,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.build.</groupId>
+        <artifactId>spec-version-maven-plugin-it-parent</artifactId>
+        <version>2.1-SNAPSHOT</version>
+    </parent>
+
     <groupId>${aubergine.groupId}</groupId>
     <artifactId>${aubergine.artifactId}</artifactId>
     <version>${aubergine.mavenVersion}</version>

--- a/src/it/modules/javax.aubergine-api/pom.xml
+++ b/src/it/modules/javax.aubergine-api/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.build.</groupId>
         <artifactId>spec-version-maven-plugin-it-parent</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>@project.version@</version>
     </parent>
 
     <groupId>${aubergine.groupId}</groupId>

--- a/src/it/modules/javax.aubergine/pom.xml
+++ b/src/it/modules/javax.aubergine/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.build.</groupId>
         <artifactId>spec-version-maven-plugin-it-parent</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>@project.version@</version>
     </parent>
 
     <groupId>${moussaka.groupId}</groupId>

--- a/src/it/modules/javax.aubergine/pom.xml
+++ b/src/it/modules/javax.aubergine/pom.xml
@@ -86,14 +86,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
-                <configuration>
-                    <useDefaultManifestFile>true</useDefaultManifestFile>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/modules/javax.aubergine/pom.xml
+++ b/src/it/modules/javax.aubergine/pom.xml
@@ -67,24 +67,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.5</version>
-                <executions>
-                    <execution>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                        <configuration>
-                           <instructions>
-                               <Bundle-Version>${spec.bundle.version}</Bundle-Version>
-                               <Bundle-SymbolicName>${spec.bundle.symbolic-name}</Bundle-SymbolicName>
-                               <Extension-Name>${spec.extension.name}</Extension-Name>
-                               <Implementation-Version>${spec.implementation.version}</Implementation-Version>
-                               <Specification-Version>${spec.specification.version}</Specification-Version>
-                           </instructions>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/it/modules/javax.aubergine/pom.xml
+++ b/src/it/modules/javax.aubergine/pom.xml
@@ -94,14 +94,6 @@
                     <useDefaultManifestFile>true</useDefaultManifestFile>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/modules/javax.aubergine/pom.xml
+++ b/src/it/modules/javax.aubergine/pom.xml
@@ -38,7 +38,6 @@
             <plugin>
                 <groupId>org.glassfish.build</groupId>
                 <artifactId>spec-version-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <configuration>
                     <specMode>${moussaka.specMode}</specMode>
                     <spec>
@@ -55,14 +54,6 @@
                         <implNamespace>${moussaka.implNamespace}</implNamespace>                        
                     </spec>
                 </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>set-spec-properties</goal>
-                            <goal>check-module</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/it/modules/javax.aubergine/pom.xml
+++ b/src/it/modules/javax.aubergine/pom.xml
@@ -64,10 +64,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/modules/javax.aubergine/pom.xml
+++ b/src/it/modules/javax.aubergine/pom.xml
@@ -19,6 +19,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.build.</groupId>
+        <artifactId>spec-version-maven-plugin-it-parent</artifactId>
+        <version>2.1-SNAPSHOT</version>
+    </parent>
+
     <groupId>${moussaka.groupId}</groupId>
     <artifactId>${moussaka.artifactId}</artifactId>
     <version>${moussaka.mavenVersion}</version>

--- a/src/it/modules/javax.aubergine/pom.xml
+++ b/src/it/modules/javax.aubergine/pom.xml
@@ -32,14 +32,6 @@
 
     <name>Moussaka project, implementation of Aubergine API</name>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
-    
     <build>
         <finalName>${moussaka.finalName}</finalName>
         <plugins>

--- a/src/it/modules/javax.courgette-api/pom.xml
+++ b/src/it/modules/javax.courgette-api/pom.xml
@@ -19,6 +19,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.build.</groupId>
+        <artifactId>spec-version-maven-plugin-it-parent</artifactId>
+        <version>2.1-SNAPSHOT</version>
+    </parent>
+
     <groupId>${courgette.groupId}</groupId>
     <artifactId>${courgette.artifactId}</artifactId>
     <version>${courgette.mavenVersion}</version>

--- a/src/it/modules/javax.courgette-api/pom.xml
+++ b/src/it/modules/javax.courgette-api/pom.xml
@@ -32,14 +32,6 @@
 
     <name>Courgette API</name>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
-    
     <build>
         <finalName>${courgette.finalName}</finalName>
         <plugins>

--- a/src/it/modules/javax.courgette-api/pom.xml
+++ b/src/it/modules/javax.courgette-api/pom.xml
@@ -55,14 +55,6 @@
                         <implNamespace>${courgette.implNamespace}</implNamespace>
                     </spec>
                 </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>set-spec-properties</goal>
-                            <goal>check-module</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/it/modules/javax.courgette-api/pom.xml
+++ b/src/it/modules/javax.courgette-api/pom.xml
@@ -86,14 +86,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
-                <configuration>
-                    <useDefaultManifestFile>true</useDefaultManifestFile>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/modules/javax.courgette-api/pom.xml
+++ b/src/it/modules/javax.courgette-api/pom.xml
@@ -67,24 +67,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.5</version>
-                <executions>
-                    <execution>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                        <configuration>
-                           <instructions>
-                               <Bundle-Version>${spec.bundle.version}</Bundle-Version>
-                               <Bundle-SymbolicName>${spec.bundle.symbolic-name}</Bundle-SymbolicName>
-                               <Extension-Name>${spec.extension.name}</Extension-Name>
-                               <Implementation-Version>${spec.implementation.version}</Implementation-Version>
-                               <Specification-Version>${spec.specification.version}</Specification-Version>
-                           </instructions>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/it/modules/javax.courgette-api/pom.xml
+++ b/src/it/modules/javax.courgette-api/pom.xml
@@ -94,14 +94,6 @@
                     <useDefaultManifestFile>true</useDefaultManifestFile>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/modules/javax.courgette-api/pom.xml
+++ b/src/it/modules/javax.courgette-api/pom.xml
@@ -64,10 +64,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/modules/javax.courgette-api/pom.xml
+++ b/src/it/modules/javax.courgette-api/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.build.</groupId>
         <artifactId>spec-version-maven-plugin-it-parent</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>@project.version@</version>
     </parent>
 
     <groupId>${courgette.groupId}</groupId>

--- a/src/it/modules/javax.courgette/pom.xml
+++ b/src/it/modules/javax.courgette/pom.xml
@@ -55,14 +55,6 @@
                         <implNamespace>${ratatouille.implNamespace}</implNamespace>
                     </spec>
                 </configuration>              
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>set-spec-properties</goal>
-                            <goal>check-module</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/it/modules/javax.courgette/pom.xml
+++ b/src/it/modules/javax.courgette/pom.xml
@@ -86,14 +86,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
-                <configuration>
-                    <useDefaultManifestFile>true</useDefaultManifestFile>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/modules/javax.courgette/pom.xml
+++ b/src/it/modules/javax.courgette/pom.xml
@@ -67,24 +67,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.5</version>
-                <executions>
-                    <execution>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>manifest</goal>
-                        </goals>
-                        <configuration>
-                           <instructions>
-                               <Bundle-Version>${spec.bundle.version}</Bundle-Version>
-                               <Bundle-SymbolicName>${spec.bundle.symbolic-name}</Bundle-SymbolicName>
-                               <Extension-Name>${spec.extension.name}</Extension-Name>
-                               <Implementation-Version>${spec.implementation.version}</Implementation-Version>
-                               <Specification-Version>${spec.specification.version}</Specification-Version>
-                           </instructions>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/it/modules/javax.courgette/pom.xml
+++ b/src/it/modules/javax.courgette/pom.xml
@@ -94,14 +94,6 @@
                     <useDefaultManifestFile>true</useDefaultManifestFile>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12</version>
-                <configuration>
-                    <skipTests>true</skipTests>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/modules/javax.courgette/pom.xml
+++ b/src/it/modules/javax.courgette/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.build.</groupId>
         <artifactId>spec-version-maven-plugin-it-parent</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>@project.version@</version>
     </parent>
 
     <groupId>${ratatouille.groupId}</groupId>

--- a/src/it/modules/javax.courgette/pom.xml
+++ b/src/it/modules/javax.courgette/pom.xml
@@ -32,14 +32,6 @@
 
     <name>Ratatouille Project, implementation of Courgette API</name>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
-    
     <build>
         <finalName>${ratatouille.finalName}</finalName>
         <plugins>

--- a/src/it/modules/javax.courgette/pom.xml
+++ b/src/it/modules/javax.courgette/pom.xml
@@ -64,10 +64,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/modules/javax.courgette/pom.xml
+++ b/src/it/modules/javax.courgette/pom.xml
@@ -19,6 +19,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.glassfish.build.</groupId>
+        <artifactId>spec-version-maven-plugin-it-parent</artifactId>
+        <version>2.1-SNAPSHOT</version>
+    </parent>
+
     <groupId>${ratatouille.groupId}</groupId>
     <artifactId>${ratatouille.artifactId}</artifactId>
     <version>${ratatouille.mavenVersion}</version>

--- a/src/it/modules/pom.xml
+++ b/src/it/modules/pom.xml
@@ -32,4 +32,20 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.12</version>
+                    <configuration>
+                        <skipTests>true</skipTests>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
 </project>

--- a/src/it/modules/pom.xml
+++ b/src/it/modules/pom.xml
@@ -76,6 +76,12 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/src/it/modules/pom.xml
+++ b/src/it/modules/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.build.</groupId>
     <artifactId>spec-version-maven-plugin-it-parent</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>@project.version@</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/src/it/modules/pom.xml
+++ b/src/it/modules/pom.xml
@@ -52,6 +52,28 @@
                         <useDefaultManifestFile>true</useDefaultManifestFile>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>2.3.5</version>
+                    <executions>
+                        <execution>
+                            <phase>process-classes</phase>
+                            <goals>
+                                <goal>manifest</goal>
+                            </goals>
+                            <configuration>
+                               <instructions>
+                                   <Bundle-Version>${spec.bundle.version}</Bundle-Version>
+                                   <Bundle-SymbolicName>${spec.bundle.symbolic-name}</Bundle-SymbolicName>
+                                   <Extension-Name>${spec.extension.name}</Extension-Name>
+                                   <Implementation-Version>${spec.implementation.version}</Implementation-Version>
+                                   <Specification-Version>${spec.specification.version}</Specification-Version>
+                               </instructions>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/src/it/modules/pom.xml
+++ b/src/it/modules/pom.xml
@@ -1,0 +1,35 @@
+<!--
+
+    Copyright (c) 2020 Eclipse Foundation and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.glassfish.build.</groupId>
+    <artifactId>spec-version-maven-plugin-it-parent</artifactId>
+    <version>2.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+</project>

--- a/src/it/modules/pom.xml
+++ b/src/it/modules/pom.xml
@@ -44,6 +44,14 @@
                         <skipTests>true</skipTests>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.4</version>
+                    <configuration>
+                        <useDefaultManifestFile>true</useDefaultManifestFile>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/src/it/modules/pom.xml
+++ b/src/it/modules/pom.xml
@@ -74,6 +74,19 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.glassfish.build</groupId>
+                    <artifactId>spec-version-maven-plugin</artifactId>
+                    <version>${project.version}</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>set-spec-properties</goal>
+                                <goal>check-module</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
I propose to introduce new pom (`src/it/modules/pom.xml`), that all IT modules would be children of. This parent may collect all common settings, leaving for modules to configure tested `spec-version-maven-plugin` only.