### PR TITLE
Bump JDK used on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation. All rights reserved.
  * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -30,7 +30,7 @@ pipeline {
   stages {
     stage('build') {
       tools {
-        jdk 'temurin-jdk11-latest'
+        jdk 'temurin-jdk21-latest'
         maven 'apache-maven-latest'
       }
       steps {


### PR DESCRIPTION
Still
https://github.com/eclipse-ee4j/glassfish-spec-version-maven-plugin/blob/61073186155c77948f72ac29d485826e7f1ac34a/pom.xml#L280
but some tools start to require newer Java, like
- #226 